### PR TITLE
Update README and front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ You should do your work in a fork under your own github account:
 * Fork this repository in github using the fork button at https://github.com/vlsci/lscc_docs .
 * Clone your fork to your local computer, e.g.: `git clone https://github.com/<your_account>/lscc_docs`
 
+It is often a good idea to make a separate branch in your fork to work on your changes.
+
 ### Sync with upstream
 
 If the repository has been edited since you forked it, you will need to bring your fork up to date before you can contribute changes:
@@ -117,6 +119,8 @@ Open your fork in github at `https://github.com/<your_account>/lscc_docs` and cr
 If your fork is up to date, you should see "These branches can be automatically merged" while you are creating the pull request. If your fork is *not* up to date you should bring it up to date (see [Sync with upstream](#sync-with-upstream))) and resolve any merge conflicts before creating the pull request.
 
 Ideally you should have someone else check and merge your pull request rather than do it yourself. Suggested reviewers for each tutorial are in that tutorial's `README.md`.
+
+Preferably, change one major thing per pull request - e.g. edit one tutorial in one pull request, and make a separate pull request if you want to edit another tutorial.
 
 ## Merging and deploying a pull request
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,5 @@
-[![Melbourne Bioinformatics Logo](img/melbioinf_logo.png)](https://www.melbournebioinformatics.org.au/)
+[![Melbourne Bioinformatics Logo](../img/melbioinf_logo.png)](https://www.melbournebioinformatics.org.au/)
 
-# Bioinformatics Documentation
+# Tutorials and protocols
 
-## Contents
-
-* [Tutorials and Protocols](tutorials/index.md)
+These tutorials have been developed by bioinformaticians at Melbourne Bioinformatics (formerly VLSCI). They are regularly delivered on-site or may be run in-house for your group. Many of the training materials were developed for use on the [Australian-made Genomics Virtual Laboratory](https://www.genome.edu.au/learn/) and these are used in our formal workshops and are also available for use to deliver your own workshops or for self-directed learning.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-[![Melbourne Bioinformatics Logo](../img/melbioinf_logo.png)](https://www.melbournebioinformatics.org.au/)
+[![Melbourne Bioinformatics Logo](img/melbioinf_logo.png)](https://www.melbournebioinformatics.org.au/)
 
 # Tutorials and protocols
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,5 +1,0 @@
-[![Melbourne Bioinformatics Logo](../img/melbioinf_logo.png)](https://www.melbournebioinformatics.org.au/)
-
-# Tutorials and protocols
-
-These tutorials have been developed by bioinformaticians at Melbourne Bioinformatics (formerly VLSCI). They are regularly delivered on-site or may be run in-house for your group. Many of the training materials were developed for use on the [Australian-made Genomics Virtual Laboratory](https://www.genome.edu.au/learn/) and these are used in our formal workshops and are also available for use to deliver your own workshops or for self-directed learning.

--- a/material-theme-overrides/partials/footer.html
+++ b/material-theme-overrides/partials/footer.html
@@ -1,0 +1,23 @@
+{% import "partials/language.html" as lang %}
+<!-- This is just a copy of the mkdocs-material footer.html with the Prev/Next page navigation removed.-->
+<footer class="md-footer">
+  <div class="md-footer-meta md-typeset">
+    <div class="md-footer-meta__inner md-grid">
+      <div class="md-footer-copyright">
+        {% if config.copyright %}
+          <div class="md-footer-copyright__highlight">
+            {{ config.copyright }}
+          </div>
+        {% endif %}
+        powered by
+        <a href="http://www.mkdocs.org" title="MkDocs">MkDocs</a>
+        and
+        <a href="http://squidfunk.github.io/mkdocs-material/" title="Material for MkDocs">
+          Material for MkDocs</a>
+      </div>
+      {% block social %}
+        {% include "partials/social.html" %}
+      {% endblock %}
+    </div>
+  </div>
+</footer>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ extra_css:
 copyright: <a href="https://www.melbournebioinformatics.org.au/">Melbourne Bioinformatics</a>
 
 pages:
-- 'Home': 'tutorials/index.md'
+- 'Home': 'index.md'
 - 'General Tutorials':
   - 'Python Overview': 'tutorials/python_overview/python_overview.md'
   - 'Using Git and Github for revision control': 'tutorials/using_git/Using_Git.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ repo_url: https://github.com/vlsci/lscc_docs
 
 # needs pip install mkdocs-material
 theme: 'material'
+theme_dir: 'material-theme-overrides'
 extra:
     feature:
         tabs: false


### PR DESCRIPTION
More restructuring fixes:

The index page is now at the root url, not at `/tutorials`. This prevents the index page being at `/tutorials/tutorials` when deployed into the website.

The Material theme default footer includes a Prev/Next page navigation on the home page by default, which isn't really appropriate for us (it suggests that whichever tutorial happens to be first in the list should be read first). Have removed this part of the footer.

Also made minor README instruction changes as per Simon's suggestions on https://github.com/vlsci/lscc_docs/pull/33. 

You should be able to preview changes at http://claresloggett.github.io/lscc_docs/ (note, not at http://claresloggett.github.io/lscc_docs/tutorials/ )